### PR TITLE
pod install breaks for "Jetfire". pod will install if change it to "jetfire".

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@ platform :ios, '8.0'
 
 link_with 'RCTWebSocket', 'RCTWebSocketTests'
 
-pod 'Jetfire', '0.1.2'
+pod 'jetfire', '0.1.2'
 pod 'React', '0.4.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - React/Core (0.4.0)
 
 DEPENDENCIES:
-  - Jetfire (= 0.1.2)
+  - jetfire (= 0.1.2)
   - React (= 0.4.0)
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
Seems like a typo. Is it?
